### PR TITLE
Last address store for Primary

### DIFF
--- a/commonheaders.h
+++ b/commonheaders.h
@@ -38,6 +38,10 @@ std::string getServerDir(int machine_id){
         return "/users/oahmed4/.server" +  std::to_string(machine_id);
 }
 
-std::string getServerPath(std::string address, int machine_id) {
+std::string getServerPath(int machine_id) {
     return getServerDir(machine_id) + "/bs" ;//"/file_" + address;
+}
+
+std::string getLastAddressPath(machine_id) {
+    return getServerDir(machine_id) + "/lastaddr" ;//"/file_" + address;
 }

--- a/commonheaders.h
+++ b/commonheaders.h
@@ -42,6 +42,6 @@ std::string getServerPath(int machine_id) {
     return getServerDir(machine_id) + "/bs" ;//"/file_" + address;
 }
 
-std::string getLastAddressPath(machine_id) {
+std::string getLastAddressPath(int machine_id) {
     return getServerDir(machine_id) + "/lastaddr" ;//"/file_" + address;
 }

--- a/protos/primarybackup.proto
+++ b/protos/primarybackup.proto
@@ -8,7 +8,7 @@ service PrimaryBackup {
     
     // when the backup comes up, it initiates a sync 
     // operation and gets it state up to date. 
-    rpc Sync(HeartBeat) returns (stream WriteRequest) {}
+    rpc Sync(SyncReq) returns (stream WriteRequest) {}
 
     // return heartbeat with state INIT if there are 
     // pending items in the log. 
@@ -45,6 +45,18 @@ message HeartBeat {
         READY = 1;
     }
     State state = 1;
+}
+
+message SyncReq {
+    enum State {
+        // can be used when doing the catch up work after failure
+        INIT = 0;
+
+        // when in normal operation
+        READY = 1;
+    }
+    State state = 1;
+    int32 last_address = 2;
 }
 
 message WriteRequest {

--- a/server.cc
+++ b/server.cc
@@ -141,14 +141,10 @@ void start_transition_log(const WriteRequest write_request) {
 
 void local_write(void) {
     const auto path = getServerPath(server_id);
-    std::cout << "WIFS server PATH WRITE TO: " << path << std::endl;
-
     const int fd = ::open(path.c_str(), O_RDWR | O_CREAT, S_IRWXU | S_IRWXG);
     if (fd == -1) std::cout << "open failed " << strerror(errno) << "\n";
 
     const auto lastaddr = getLastAddressPath(server_id);
-    std::cout << "WIFS SERVER last address path: " << lastaddr << std::endl;
-
     const int fd_lastaddr = ::open(lastaddr.c_str(), O_RDWR | O_CREAT, S_IRWXU | S_IRWXG);
     if (fd_lastaddr == -1) std::cout << "fd_lastaddr open failed " << strerror(errno) << "\n";
 
@@ -160,10 +156,12 @@ void local_write(void) {
         const WriteReq* request = node->req;
 	    if(node->req->crash_mode() == wifs::WriteReq_Crash_PRIMARY_CRASH_BEFORE_LOCAL_WRITE_AFTER_REMOTE) while(true);
 
+        std::cout << "WIFS SERVER last address path: " << lastaddr << std::endl;
         lseek(fd_lastaddr,0,SEEK_SET);
         int rc_addr = write(fd_lastaddr, std::to_string(request->address()).c_str(), MAX_PATH_LENGTH);
         if (rc_addr == -1) std::cout << "last address write failed " << strerror(errno) << "\n";
 
+        std::cout << "WIFS server PATH WRITE TO: " << path << std::endl;
         int rc = pwrite(fd, (void*)request->buf().c_str(), BLOCK_SIZE, request->address());
 
         if (rc == -1) std::cout << "write failed " << strerror(errno) << "\n";

--- a/server.cc
+++ b/server.cc
@@ -145,7 +145,7 @@ void local_write(void) {
     if (fd == -1) std::cout << "open failed " << strerror(errno) << "\n";
 
     const auto lastaddr = getLastAddressPath(server_id);
-    const int fd_lastaddr = ::open(lastaddr.c_str(), O_RDWR | O_CREAT, S_IRWXU | S_IRWXG);
+    const int fd_lastaddr = ::open(lastaddr.c_str(), O_TRUNC| O_RDWR | O_CREAT, S_IRWXU | S_IRWXG);
     if (fd_lastaddr == -1) std::cout << "fd_lastaddr open failed " << strerror(errno) << "\n";
 
     while (true) {
@@ -157,7 +157,9 @@ void local_write(void) {
 	    if(node->req->crash_mode() == wifs::WriteReq_Crash_PRIMARY_CRASH_BEFORE_LOCAL_WRITE_AFTER_REMOTE) while(true);
 
         std::cout << "WIFS SERVER last address path: " << lastaddr << std::endl;
-        int rc_addr = pwrite(fd_lastaddr, std::to_string(request->address()).c_str(), MAX_PATH_LENGTH, 0);
+	const auto char_addr = std::to_string(request->address()).c_str();
+	std::cout << "last address writing to file: "<< char_addr << std::endl;
+        int rc_addr = pwrite(fd_lastaddr, char_addr, MAX_PATH_LENGTH, 0);
         if (rc_addr == -1) std::cout << "last address write failed " << strerror(errno) << "\n";
 
         std::cout << "WIFS server PATH WRITE TO: " << path << std::endl;

--- a/server.cc
+++ b/server.cc
@@ -276,13 +276,14 @@ class PrimarybackupServiceImplementation final : public PrimaryBackup::Service {
     Status Sync(ServerContext* context, const SyncReq* request, ServerWriter<WriteRequest>* writer) {
         //replay last write that happened when the server went down
         if (request->last_address() != -1) {
-            other_node_syncing = true
+            other_node_syncing = true;
             WriteRequest write_request;
             char data[BLOCK_SIZE];
 	        const auto path = getServerPath(server_id);
             const int fd = ::open(path.c_str(), O_RDONLY);
             pread(fd, data, BLOCK_SIZE, request->last_address());
             std::string buffer(data);
+	    std::cout << "Last address overwrite: " <<std::endl;
             write_request.set_blk_address(request->last_address());
             write_request.set_buffer(data);
             writer->Write(write_request);

--- a/server.cc
+++ b/server.cc
@@ -44,6 +44,7 @@ using wifs::WriteReq;
 using wifs::WriteRes;
 
 using primarybackup::HeartBeat;
+using primarybackup::SyncReq;
 using primarybackup::InitReq;
 using primarybackup::InitRes;
 using primarybackup::PrimaryBackup;
@@ -139,11 +140,17 @@ void start_transition_log(const WriteRequest write_request) {
 }
 
 void local_write(void) {
-    const auto path = getServerPath(std::string("doesn't matter"), server_id);
+    const auto path = getServerPath(server_id);
     std::cout << "WIFS server PATH WRITE TO: " << path << std::endl;
 
     const int fd = ::open(path.c_str(), O_RDWR | O_CREAT, S_IRWXU | S_IRWXG);
     if (fd == -1) std::cout << "open failed " << strerror(errno) << "\n";
+
+    const auto lastaddr = getLastAddressPath(server_id);
+    std::cout << "WIFS SERVER last address path: " << lastaddr << std::endl;
+
+    const int fd_lastaddr = ::open(lastaddr.c_str(), O_RDWR | O_CREAT, S_IRWXU | S_IRWXG);
+    if (fd_lastaddr == -1) std::cout << "fd_lastaddr open failed " << strerror(errno) << "\n";
 
     while (true) {
         sem_wait(&sem_queue);
@@ -152,8 +159,13 @@ void local_write(void) {
 
         const WriteReq* request = node->req;
 	    if(node->req->crash_mode() == wifs::WriteReq_Crash_PRIMARY_CRASH_BEFORE_LOCAL_WRITE_AFTER_REMOTE) while(true);
-        
+
+        lseek(fd_lastaddr,0,SEEK_SET);
+        int rc_addr = write(fd_lastaddr, request->address().c_str(), MAX_PATH_LENGTH);
+        if (rc_addr == -1) std::cout << "last address write failed " << strerror(errno) << "\n";
+
         int rc = pwrite(fd, (void*)request->buf().c_str(), BLOCK_SIZE, request->address());
+
         if (rc == -1) std::cout << "write failed " << strerror(errno) << "\n";
         node->promise_obj.set_value(rc);
 
@@ -264,7 +276,15 @@ class PrimarybackupServiceImplementation final : public PrimaryBackup::Service {
         return Status::OK;
     }
 
-    Status Sync(ServerContext* context, const HeartBeat* request, ServerWriter<WriteRequest>* writer) {
+    Status Sync(ServerContext* context, const SyncReq* request, ServerWriter<WriteRequest>* writer) {
+        //replay last write that happened when the server went down
+        if (request->last_address() != -1) {
+            WriteRequest write_request;
+            write_request.set_blk_address(request->address());
+            write_request.set_buffer(BLOCK_SIZE);
+            writer->Write(write_request);
+        }
+
         int pending_writes = 0;
         sem_getvalue(&sem_log_queue, &pending_writes);
         if (pending_writes) other_node_syncing = true;
@@ -367,7 +387,7 @@ class WifsServiceImplementation final : public WIFS::Service {
             return Status::OK;
         }
 
-        const auto path = getServerPath(std::to_string(request->address()), server_id);
+        const auto path = getServerPath(server_id);
         std::cout << "WIFS server PATH READ: " << path << std::endl;
 
         const int fd = ::open(path.c_str(), O_RDONLY);
@@ -501,15 +521,33 @@ void check_heartbeat() {
     }
 }
 
+int get_last_addr(){
+    //check if lastadd exists
+    const int fd_lastaddr = ::open(lastaddr.c_str(), O_RDWR | O_CREAT, S_IRWXU | S_IRWXG);
+    if (fd_lastaddr == -1) std::cout << "fd_lastaddr open failed " << strerror(errno) << "\n";
+
+    char last_address[MAX_PATH_LENGTH];
+    pread(fd_lastaddr, last_address, MAX_PATH_LENGTH, 0);
+    int l_addr = -1;
+    if (strcmp(last_address,"")!=0){
+        l_addr = atoi(last_address);
+        //need to write blank into last_address after retrieving??
+    }
+    return l_addr;
+}
+
 void update_state_to_latest(int retry_count) {
-    HeartBeat request;
+    SyncReq request;
     ClientContext context;
+
+    request.set_last_address = get_last_addr();
+
     std::unique_ptr<ClientReader<WriteRequest> > reader(client_stub_->Sync(&context, request));
     WriteRequest reply;
     while (reader->Read(&reply)) {
         // don't use the write queue since that will add an overhead of populating a promise obj each time.
         // sync write should be fast, and not like write in normal operation
-        const auto path = getServerPath(std::to_string(reply.blk_address()), server_id);
+        const auto path = getServerPath(server_id);
         std::cout << "WIFS server PATH WRITE TO: " << path << std::endl;
 
         const int fd = ::open(path.c_str(), O_RDWR | O_CREAT, S_IRWXU | S_IRWXG);


### PR DESCRIPTION
Before local write in primary, save write address to file.
Handles case when primary crashes after local write and before remote write.
When a server comes up it will fetch the block written at the address stored in last_address file from the Primary during Sync operation.